### PR TITLE
Sanely inject Sodium thru client and server

### DIFF
--- a/client/src/main/java/com/collarmc/client/Collar.java
+++ b/client/src/main/java/com/collarmc/client/Collar.java
@@ -43,6 +43,7 @@ import com.collarmc.protocol.session.StartSessionRequest;
 import com.collarmc.protocol.session.StartSessionResponse;
 import com.collarmc.security.messages.CipherException;
 import com.collarmc.security.messages.CipherException.InvalidCipherSessionException;
+import com.collarmc.security.messages.CollarSodium;
 import com.collarmc.security.mojang.MinecraftSession;
 import com.collarmc.security.mojang.Mojang;
 import com.collarmc.utils.Utils;
@@ -74,6 +75,7 @@ public final class Collar {
     private final IdentityApi identityApi;
     private final MessagingApi messagingApi;
     private final SDHTApi sdhtApi;
+    private final CollarSodium sodium;
     private WebSocket webSocket;
     private volatile State state;
     private final List<AbstractApi> apis;
@@ -92,6 +94,7 @@ public final class Collar {
         this.recordCiphers = new ContentCiphers();
         this.apis = new ArrayList<>();
         this.sdhtApi = new SDHTApi(this, identityStoreSupplier, sender, recordCiphers, this.ticks, this.configuration.homeDirectory.dhtState());
+        this.sodium = new CollarSodium(false);
         this.groupsApi = new GroupsApi(this, identityStoreSupplier, sender, sdhtApi);
         this.recordCiphers.register(new GroupContentCipher(groupsApi, identityStoreSupplier));
         this.locationApi = new LocationApi(this,
@@ -340,7 +343,7 @@ public final class Collar {
             };
             LOGGER.info("Connection established");
             try {
-                identityStore = new ClientIdentityStoreImpl(configuration.homeDirectory);
+                identityStore = new ClientIdentityStoreImpl(configuration.homeDirectory, this.collar.sodium);
             } catch (IOException | CipherException e) {
                 throw new IllegalStateException("could not load identity store");
             }

--- a/server/src/main/java/com/collarmc/server/Services.java
+++ b/server/src/main/java/com/collarmc/server/Services.java
@@ -2,6 +2,7 @@ package com.collarmc.server;
 
 import com.collarmc.api.authentication.AuthenticationService;
 import com.collarmc.api.profiles.ProfileService;
+import com.collarmc.security.messages.CollarSodium;
 import com.collarmc.server.configuration.Configuration;
 import com.collarmc.server.http.AppUrlProvider;
 import com.collarmc.server.security.ServerIdentityStore;
@@ -44,12 +45,14 @@ public final class Services {
     public final WaypointService waypoints;
     public final ClientRegistrationService deviceRegistration;
     public final ProfileCache profileCache;
+    public final CollarSodium collarSodium;
 
     public Services(Configuration configuration) throws Exception {
         this.jsonMapper = Utils.jsonMapper();
         this.packetMapper = Utils.messagePackMapper();
         this.urlProvider = configuration.appUrlProvider;
-        this.identityStore = new ServerIdentityStoreImpl(configuration.database);
+        this.collarSodium = new CollarSodium(true);
+        this.identityStore = new ServerIdentityStoreImpl(configuration.database, collarSodium);
         this.sessions = new SessionManager(packetMapper, identityStore);
         this.deviceRegistration = new ClientRegistrationService(sessions, identityStore);
         this.passwordHashing = configuration.passwordHashing;

--- a/server/src/main/java/com/collarmc/server/WebServer.java
+++ b/server/src/main/java/com/collarmc/server/WebServer.java
@@ -55,7 +55,6 @@ public class WebServer {
 
     public void start(Consumer<Services> callback) throws Exception {
         LOGGER.info("Reticulating splines...");
-        SodiumCipher.loadLibrary(true);
         // Set http port
         port(configuration.httpPort);
         // Services

--- a/shared/src/main/java/com/collarmc/security/CollarIdentity.java
+++ b/shared/src/main/java/com/collarmc/security/CollarIdentity.java
@@ -2,9 +2,7 @@ package com.collarmc.security;
 
 import com.collarmc.api.identity.ServerIdentity;
 import com.collarmc.io.IO;
-import com.collarmc.security.messages.CipherException;
-import com.collarmc.security.messages.IdentityStore;
-import com.collarmc.security.messages.SodiumCipher;
+import com.collarmc.security.messages.*;
 import com.goterl.lazysodium.utils.Key;
 import com.goterl.lazysodium.utils.KeyPair;
 
@@ -83,12 +81,12 @@ public final class CollarIdentity {
         }
     }
 
-    public static CollarIdentity createClientIdentity(UUID profile, ServerIdentity serverIdentity) throws CipherException {
-        return new CollarIdentity(profile, serverIdentity, SodiumCipher.generateKeyPair());
+    public static CollarIdentity createClientIdentity(UUID profile, ServerIdentity serverIdentity, CollarSodium sodium) throws CipherException {
+        return new CollarIdentity(profile, serverIdentity, sodium.generateKeyPair());
     }
 
-    public static CollarIdentity createServerIdentity() throws CipherException {
-        return new CollarIdentity(UUID.randomUUID(), null, SodiumCipher.generateKeyPair());
+    public static CollarIdentity createServerIdentity(CollarSodium sodium) throws CipherException {
+        return new CollarIdentity(UUID.randomUUID(), null, sodium.generateKeyPair());
     }
 
     public static CollarIdentity serverIdentityFrom(UUID profile, byte[] publicKey, byte[] privateKey) {

--- a/shared/src/main/java/com/collarmc/security/messages/Cipher.java
+++ b/shared/src/main/java/com/collarmc/security/messages/Cipher.java
@@ -2,6 +2,7 @@ package com.collarmc.security.messages;
 
 import com.collarmc.api.identity.Identity;
 import com.collarmc.security.PublicKey;
+import com.goterl.lazysodium.utils.KeyPair;
 
 public interface Cipher {
     /**

--- a/shared/src/main/java/com/collarmc/security/messages/CollarSodium.java
+++ b/shared/src/main/java/com/collarmc/security/messages/CollarSodium.java
@@ -1,0 +1,73 @@
+package com.collarmc.security.messages;
+
+import com.google.common.io.ByteStreams;
+import com.goterl.lazysodium.LazySodiumJava;
+import com.goterl.lazysodium.SodiumJava;
+import com.goterl.lazysodium.exceptions.SodiumException;
+import com.goterl.lazysodium.utils.KeyPair;
+import com.goterl.lazysodium.utils.LibraryLoader;
+import com.sun.jna.Platform;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+
+public class CollarSodium {
+
+    private final LazySodiumJava sodium;
+
+    public CollarSodium(boolean server) {
+        this.sodium = loadLibrary(server);
+    }
+
+    public LazySodiumJava getSodium() {
+        return sodium;
+    }
+
+    public KeyPair generateKeyPair() throws CipherException {
+        try {
+            return sodium.cryptoBoxKeypair();
+        } catch (SodiumException e) {
+            throw new CipherException("Could not generate key pair", e);
+        }
+    }
+
+    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
+    private LazySodiumJava loadLibrary(boolean server) {
+        if (server && Platform.is64Bit() && Platform.isLinux()) {
+            File file = new File("/usr/lib/x86_64-linux-gnu/libsodium.so.23");
+            if (!file.exists()) {
+                throw new IllegalStateException("libsodium is not installed");
+            }
+            return new LazySodiumJava(new SodiumJava(file.getAbsolutePath()));
+        } else {
+            String path = LibraryLoader.getSodiumPathInResources();
+            File lib;
+            try {
+                lib = File.createTempFile("sodium", ".lib");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            try (InputStream is = SodiumCipher.class.getResourceAsStream("/" + path);
+                 FileOutputStream os = new FileOutputStream(lib)) {
+                if (is == null) {
+                    throw new IllegalStateException("could not find " + path);
+                }
+                ByteStreams.copy(is, os);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return new LazySodiumJava(new SodiumJava(lib.getAbsolutePath()));
+        }
+    }
+
+    public static class CollarSodiumJava extends SodiumJava {
+        public CollarSodiumJava(String absolutePath) {
+            super(absolutePath);
+            new LibraryLoader(Collections.singletonList(CollarSodiumJava.class)).loadAbsolutePath(absolutePath);
+        }
+    }
+}


### PR DESCRIPTION
Generating a keypair for the first time on client previously resulted in a NullPointerException as SodiumCipher was not initialized. Decided to clean up how sodium was being loaded and injected throughout the application to avoid troublesome static functions that rely on non-static objects (you're gonna have a bad time).
