### PR TITLE
Clean up unnecessary Sodium loaders and wrappers

### DIFF
--- a/client/src/main/java/com/collarmc/client/Collar.java
+++ b/client/src/main/java/com/collarmc/client/Collar.java
@@ -94,7 +94,7 @@ public final class Collar {
         this.recordCiphers = new ContentCiphers();
         this.apis = new ArrayList<>();
         this.sdhtApi = new SDHTApi(this, identityStoreSupplier, sender, recordCiphers, this.ticks, this.configuration.homeDirectory.dhtState());
-        this.sodium = new CollarSodium(false);
+        this.sodium = new CollarSodium();
         this.groupsApi = new GroupsApi(this, identityStoreSupplier, sender, sdhtApi);
         this.recordCiphers.register(new GroupContentCipher(groupsApi, identityStoreSupplier));
         this.locationApi = new LocationApi(this,

--- a/server/src/main/java/com/collarmc/server/Services.java
+++ b/server/src/main/java/com/collarmc/server/Services.java
@@ -51,7 +51,7 @@ public final class Services {
         this.jsonMapper = Utils.jsonMapper();
         this.packetMapper = Utils.messagePackMapper();
         this.urlProvider = configuration.appUrlProvider;
-        this.collarSodium = new CollarSodium(true);
+        this.collarSodium = new CollarSodium();
         this.identityStore = new ServerIdentityStoreImpl(configuration.database, collarSodium);
         this.sessions = new SessionManager(packetMapper, identityStore);
         this.deviceRegistration = new ClientRegistrationService(sessions, identityStore);

--- a/server/src/test/java/com/collarmc/server/security/ServerIdentityStoreImplTest.java
+++ b/server/src/test/java/com/collarmc/server/security/ServerIdentityStoreImplTest.java
@@ -14,12 +14,12 @@ import java.util.UUID;
 public class ServerIdentityStoreImplTest {
     @Rule
     public MongoDatabaseTestRule dbRule = new MongoDatabaseTestRule();
+    private final CollarSodium collarSodium = new CollarSodium();
 
     @Test
     public void roundTrip() throws Exception {
-        CollarSodium sodium = new CollarSodium(false);
-        ServerIdentityStoreImpl identityStore = new ServerIdentityStoreImpl(dbRule.db, sodium);
-        ServerIdentityStoreImpl identityStore2 = new ServerIdentityStoreImpl(dbRule.db, sodium);
+        ServerIdentityStoreImpl identityStore = new ServerIdentityStoreImpl(dbRule.db, collarSodium);
+        ServerIdentityStoreImpl identityStore2 = new ServerIdentityStoreImpl(dbRule.db, collarSodium);
         Assert.assertEquals(identityStore.identity(), identityStore2.identity());
         Assert.assertEquals(identityStore.identity().id(), identityStore2.identity().id());
         Assert.assertArrayEquals(identityStore.identity().publicKey().key, identityStore2.identity().publicKey().key);
@@ -27,11 +27,10 @@ public class ServerIdentityStoreImplTest {
 
     @Test
     public void cipher() throws Exception {
-        CollarSodium sodium = new CollarSodium(false);
         // Load server once to make sure we create the identity
-        new ServerIdentityStoreImpl(dbRule.db, sodium);
+        new ServerIdentityStoreImpl(dbRule.db, collarSodium);
         // Load server identity from the database again
-        ServerIdentityStoreImpl server = new ServerIdentityStoreImpl(dbRule.db, sodium);
+        ServerIdentityStoreImpl server = new ServerIdentityStoreImpl(dbRule.db, collarSodium);
         // encrypt message
         byte[] token = TokenGenerator.byteToken(256);
         byte[] cipherText = server.cipher().encrypt(token);
@@ -42,18 +41,17 @@ public class ServerIdentityStoreImplTest {
 
     @Test
     public void serverSendsMessageToBob() throws Exception {
-        CollarSodium sodium = new CollarSodium(false);
         // Load server once to make sure we create the identity
-        new ServerIdentityStoreImpl(dbRule.db, sodium);
+        new ServerIdentityStoreImpl(dbRule.db, collarSodium);
         // Load server identity from the database again
-        ServerIdentityStoreImpl server = new ServerIdentityStoreImpl(dbRule.db, sodium);
+        ServerIdentityStoreImpl server = new ServerIdentityStoreImpl(dbRule.db, collarSodium);
         // Create bob
-        CollarIdentity bob = CollarIdentity.createClientIdentity(UUID.randomUUID(), server.identity(), sodium);
+        CollarIdentity bob = CollarIdentity.createClientIdentity(UUID.randomUUID(), server.identity(), collarSodium);
         // Encrypt message for bob
         byte[] token = TokenGenerator.byteToken(256);
         byte[] cipherText = server.cipher().encrypt(token, bob.publicKey());
         // Bob gets the message
-        byte[] decrypted = new SodiumCipher(sodium, bob.keyPair).decrypt(cipherText, server.identity().publicKey());
+        byte[] decrypted = new SodiumCipher(collarSodium, bob.keyPair).decrypt(cipherText, server.identity().publicKey());
         Assert.assertArrayEquals(token, decrypted);
     }
 }

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -13,10 +13,12 @@
         <dependency>
             <groupId>com.goterl</groupId>
             <artifactId>lazysodium-java</artifactId>
+            <version>5.1.1</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
+            <version>5.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/shared/src/main/java/com/collarmc/security/messages/CollarSodium.java
+++ b/shared/src/main/java/com/collarmc/security/messages/CollarSodium.java
@@ -1,73 +1,30 @@
 package com.collarmc.security.messages;
 
-import com.google.common.io.ByteStreams;
 import com.goterl.lazysodium.LazySodiumJava;
 import com.goterl.lazysodium.SodiumJava;
 import com.goterl.lazysodium.exceptions.SodiumException;
 import com.goterl.lazysodium.utils.KeyPair;
 import com.goterl.lazysodium.utils.LibraryLoader;
-import com.sun.jna.Platform;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
+/**
+ * Sodium library wrapper class. Handles loading on multiplatform builds.
+ */
+public class CollarSodium extends LazySodiumJava {
 
-public class CollarSodium {
-
-    private final LazySodiumJava sodium;
-
-    public CollarSodium(boolean server) {
-        this.sodium = loadLibrary(server);
+    public CollarSodium() {
+        super(new SodiumJava(LibraryLoader.Mode.PREFER_BUNDLED));
     }
 
-    public LazySodiumJava getSodium() {
-        return sodium;
-    }
-
+    /**
+     * Generates a public/private keypair.
+     * @return public/private keypair
+     * @throws CipherException
+     */
     public KeyPair generateKeyPair() throws CipherException {
         try {
-            return sodium.cryptoBoxKeypair();
+            return this.cryptoBoxKeypair();
         } catch (SodiumException e) {
             throw new CipherException("Could not generate key pair", e);
-        }
-    }
-
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-    private LazySodiumJava loadLibrary(boolean server) {
-        if (server && Platform.is64Bit() && Platform.isLinux()) {
-            File file = new File("/usr/lib/x86_64-linux-gnu/libsodium.so.23");
-            if (!file.exists()) {
-                throw new IllegalStateException("libsodium is not installed");
-            }
-            return new LazySodiumJava(new SodiumJava(file.getAbsolutePath()));
-        } else {
-            String path = LibraryLoader.getSodiumPathInResources();
-            File lib;
-            try {
-                lib = File.createTempFile("sodium", ".lib");
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            try (InputStream is = SodiumCipher.class.getResourceAsStream("/" + path);
-                 FileOutputStream os = new FileOutputStream(lib)) {
-                if (is == null) {
-                    throw new IllegalStateException("could not find " + path);
-                }
-                ByteStreams.copy(is, os);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return new LazySodiumJava(new SodiumJava(lib.getAbsolutePath()));
-        }
-    }
-
-    public static class CollarSodiumJava extends SodiumJava {
-        public CollarSodiumJava(String absolutePath) {
-            super(absolutePath);
-            new LibraryLoader(Collections.singletonList(CollarSodiumJava.class)).loadAbsolutePath(absolutePath);
         }
     }
 }

--- a/shared/src/test/java/com/collarmc/security/CollarIdentityTest.java
+++ b/shared/src/test/java/com/collarmc/security/CollarIdentityTest.java
@@ -2,19 +2,20 @@ package com.collarmc.security;
 
 import com.collarmc.api.identity.ServerIdentity;
 import com.collarmc.security.messages.CollarSodium;
-import com.collarmc.security.messages.SodiumCipher;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.UUID;
 
 public class CollarIdentityTest {
+    private final CollarSodium collarSodium = new CollarSodium();
+
     @Test
     public void roundTripClientIdentity() throws Exception {
-        CollarSodium sodium = new CollarSodium(false);
         ServerIdentity serverIdentity = new ServerIdentity(UUID.randomUUID(), new PublicKey(TokenGenerator.byteToken(16)));
         UUID profile = UUID.randomUUID();
-        CollarIdentity identity = CollarIdentity.createClientIdentity(profile, serverIdentity, sodium);
+        CollarSodium collarSodium = new CollarSodium();
+        CollarIdentity identity = CollarIdentity.createClientIdentity(profile, serverIdentity, collarSodium);
         byte[] identityBytes = identity.serialize();
         CollarIdentity newIdentity = CollarIdentity.from(identityBytes);
         Assert.assertEquals(identity.id, newIdentity.id);
@@ -26,8 +27,7 @@ public class CollarIdentityTest {
 
     @Test
     public void roundTripServerIdentity() throws Exception {
-        CollarSodium sodium = new CollarSodium(false);
-        CollarIdentity identity = CollarIdentity.createServerIdentity(sodium);
+        CollarIdentity identity = CollarIdentity.createServerIdentity(collarSodium);
         byte[] identityBytes = identity.serialize();
         CollarIdentity newIdentity = CollarIdentity.from(identityBytes);
         Assert.assertEquals(identity.id, newIdentity.id);

--- a/shared/src/test/java/com/collarmc/security/messages/SodiumCipherTest.java
+++ b/shared/src/test/java/com/collarmc/security/messages/SodiumCipherTest.java
@@ -24,14 +24,14 @@ public class SodiumCipherTest {
 
     @Before
     public void setup() throws Exception {
-        CollarSodium sodium = new CollarSodium(false);
-        server = CollarIdentity.createServerIdentity(sodium);
-        bob = CollarIdentity.createClientIdentity(UUID.randomUUID(), server.serverIdentity, sodium);
-        bobCipher = new SodiumCipher(sodium, bob.keyPair);
-        alice = CollarIdentity.createClientIdentity(UUID.randomUUID(), server.serverIdentity, sodium);
-        aliceCipher = new SodiumCipher(sodium, alice.keyPair);
-        eve = CollarIdentity.createClientIdentity(UUID.randomUUID(), server.serverIdentity, sodium);
-        eveCipher = new SodiumCipher(sodium, eve.keyPair);
+        final CollarSodium collarSodium = new CollarSodium();
+        server = CollarIdentity.createServerIdentity(collarSodium);
+        bob = CollarIdentity.createClientIdentity(UUID.randomUUID(), server.serverIdentity, collarSodium);
+        bobCipher = new SodiumCipher(collarSodium, bob.keyPair);
+        alice = CollarIdentity.createClientIdentity(UUID.randomUUID(), server.serverIdentity, collarSodium);
+        aliceCipher = new SodiumCipher(collarSodium, alice.keyPair);
+        eve = CollarIdentity.createClientIdentity(UUID.randomUUID(), server.serverIdentity, collarSodium);
+        eveCipher = new SodiumCipher(collarSodium, eve.keyPair);
     }
 
     @Test


### PR DESCRIPTION
Prefers the bundled library version of libsodium and JNA. The underlying libraries should handle the correct loading with the native platforms. @orsondmc feel free to double check if this breaks the deployed service.

Didn't realize you merged my previous PR. It was still in draft or I would have combined these.